### PR TITLE
Modal work

### DIFF
--- a/frontend_react/src/App.js
+++ b/frontend_react/src/App.js
@@ -40,12 +40,12 @@ class App extends Component {
         }
 
         <Switch>  
-          <Route exact path='/readings/new' component={ NewReading } />
-          <Route exact path='/readings' component={ ReadingSplash } />
-          <Route exact path='/cards' component={CardList}/> 
-          <Route exact path='/profile' component={Profile} />
-          <Route exact path='/' component={Welcome} />
-          <Route exact path='/signup' component={Signup} />
+          <Route path='/readings/new' component={ NewReading } />
+          <Route path='/readings' component={ ReadingSplash } />
+          <Route path='/cards' component={ CardList }/> 
+          <Route exact path='/profile' component={ Profile } />
+          <Route exact path='/' component={ Welcome } />
+          <Route exact path='/signup' component={ Signup } />
         </Switch>
 
       </div>

--- a/frontend_react/src/NavBar.js
+++ b/frontend_react/src/NavBar.js
@@ -19,26 +19,21 @@ class NavBar extends React.Component {
   "border-radius": "0"}}>
                 <h1 style={{color: "white"}}>Three Seeds Tarot</h1>
 
-                    <div className="right menu">
-                    <NavLink to="/cards">
-                        <button id="navButton" className="item" > Cards </button>
-                    </NavLink>
-                
+                <div className="right menu">
+                <NavLink to="/cards">
+                    <button id="navButton" className="item" > Cards </button>
+                </NavLink>
 
-                
-                    <NavLink to="/readings">
-                        <button id="navButton" className="item" > New Reading </button>
-                    </NavLink>
-                 
+                <NavLink to="/readings/new">
+                    <button id="navButton" className="item" > New Reading </button>
+                </NavLink>
 
-                
-                    <NavLink to="/profile">
-                        <button id="navButton" className="item" > Past Readings </button> 
-                    </NavLink>
+                <NavLink to="/profile">
+                    <button id="navButton" className="item" > Past Readings </button> 
+                </NavLink>
 
-                    
-                        <button onClick={this.handleLogout} id="logout" className="ui primary button" >Logout</button>
-                    </div>
+                <button onClick={this.handleLogout} id="logout" className="ui primary button" >Logout</button>
+                </div>
                 
             </div>
         )

--- a/frontend_react/src/components/cards/CardImage.js
+++ b/frontend_react/src/components/cards/CardImage.js
@@ -1,9 +1,11 @@
 import React from 'react';
-import CardInfo from "./CardInfo";
 import { connect } from "react-redux";
-import { selectCardAction } from '../../store/allCards/actions';
 import { withRouter } from 'react-router-dom';
+import { Modal, Header, Image } from 'semantic-ui-react';
 
+import { selectCardAction } from '../../store/allCards/actions';
+import inlineStyle from '../../modalStyle';
+import capitalize from '../../functions';
 
 class CardImage extends React.Component {
 
@@ -34,13 +36,28 @@ class CardImage extends React.Component {
     render() {
         
         return (
-            <div>
+            <div className='card-modal'>
+               
+               <Modal 
+               size='large'
+               trigger={
+                    <div className="ui medium images" > 
+                        <img className="card-image" src={this.getImage(this.props.card.name)} alt="No Image Found" onClick={this.handleClick} />
+                    </div>}
+                style={inlineStyle.modal}>
 
-                <div className="ui medium images" > 
-                    <img className="card-image" src={this.getImage(this.props.card.name)} alt="No Image Found" onClick={this.handleClick} />
-                </div>
+                    <Modal.Header>{this.props.card.name}</Modal.Header>
 
-               {this.state.showInfo === true ? <CardInfo card={this.props.card} /> : null }
+                    <Modal.Content >
+                        <Image wrapped size='medium' src={this.getImage(this.props.card.name)} floated='left' />
+                        <Modal.Description>
+                            <Header>{capitalize(this.props.card.card_type)} Arcana CARD IMAGE</Header>
+                            <p>Meaning Upright: {this.props.card.meaning_up} </p>
+                            <p>Meaning Reversed: {this.props.card.meaning_rev} </p>
+                            <p>Description: {this.props.card.desc} </p>
+                        </Modal.Description>
+                    </Modal.Content>
+                </Modal>
 
             </div>
         )

--- a/frontend_react/src/components/cards/CardInfo.js
+++ b/frontend_react/src/components/cards/CardInfo.js
@@ -1,20 +1,18 @@
 import React from 'react';
 import { connect } from 'react-redux';
-// import { selectCard } from '../../'
+
 import './cardStyles.css';
 import { selectCardAction } from '../../store/allCards/actions';
+import capitalize from '../../functions';
+// import { Modal, Header, Button } from 'semantic-ui-react';
 
 const CardInfo = (props) => {
+
+    
 
     const handleClick = (e) => {
         props.selectCard(props.card)
             
-    }
-
-    function capitalize(string) {
-        if (string !== undefined) {
-            return string.charAt(0).toUpperCase() + string.slice(1).toLowerCase();
-        }    
     }
 
     return (
@@ -23,11 +21,21 @@ const CardInfo = (props) => {
             <h3>{capitalize(props.card.card_type)} Arcana</h3>                <p><strong>Meaning Upright:</strong> {props.card.meaning_up}</p>
             <p><strong>Meaning Reversed:</strong> {props.card.meaning_rev}</p>
             <p><strong>Description:</strong> {props.card.desc} </p>
+
+            {/* <Modal trigger={<Button>Show Modal</Button>}>
+                <Modal.Header>{props.card.name}</Modal.Header>
+
+                <Modal.Content>
+                    <Modal.Description>
+                        <Header>{capitalize(props.card.card_type)}</Header>
+                        <p>Meaning Upright: {props.card.meaning_up} </p>
+                        <p>Meaning Reversed: {props.card.meaning_rev} </p>
+                        <p>Description: {props.card.desc} </p>
+                    </Modal.Description>
+                </Modal.Content>
+            </Modal> */}
         </div>
     )
-    
-    
-
 }
 
 const mapDispatchToProps = (dispatch) => ({

--- a/frontend_react/src/components/cards/CardList.js
+++ b/frontend_react/src/components/cards/CardList.js
@@ -19,9 +19,7 @@ class CardList extends React.Component {
         <div className="card-list">
             <div className="horizontal-scroll-wrapper" >
                 {cardList.map(card => 
-                
-                    <CardImage key={card.id} card={card}  /> 
-                
+                    <CardImage key={card.id} card={card} />
                 )}
             </div>
 

--- a/frontend_react/src/components/cards/cardStyles.css
+++ b/frontend_react/src/components/cards/cardStyles.css
@@ -19,12 +19,13 @@
   }
 
   .horizontal-scroll-wrapper {
-    max-width: 100%;
-    max-height: 600px;
-    /* margin: 10px auto; */
-    background: rgb(49, 86, 99);
-    border: 2px solid #000;
     display: flex;
+    flex-wrap: wrap;
+    max-width: 100%;
+    max-height: 50%;
+    /* margin: 10px auto; */
+    background: rgb(144, 170, 180);
+    border: 2px solid #000;
     align-content: center;
     overflow-x: scroll;
     white-space: normal;

--- a/frontend_react/src/components/readings/ReadingSplash.js
+++ b/frontend_react/src/components/readings/ReadingSplash.js
@@ -1,21 +1,23 @@
-import React from 'react';
-import { NavLink } from "react-router-dom";
+// import React from 'react';
+// import { NavLink } from "react-router-dom";
 
-class ReadingSplash extends React.Component {
+// class ReadingSplash extends React.Component {
 
-    render() {
-        return (
-            <div className="reading-splash">
+//     render() {
+//         return (
+//             <div className="reading-splash">
 
-                <div className="splash-header">
-                    <h1>
-                        <NavLink to="/readings/new" > Start a new reading </NavLink>
-                    </h1>
-                </div>
+//                 <div className="splash-header">
+//                     <h1>
+//                         <NavLink to="/readings/new" > Start a new reading </NavLink>
+//                     </h1>
+//                 </div>
 
-            </div>
-        )
-    }
-}
+//             </div>
+//         )
+//     }
+// }
 
-export default ReadingSplash;
+// export default ReadingSplash;
+
+// DELETE THIS WHEN YOU ARE SURE THAT IT IS UNNECESARY

--- a/frontend_react/src/components/readings/reading_types/FiveCardReading.js
+++ b/frontend_react/src/components/readings/reading_types/FiveCardReading.js
@@ -61,35 +61,15 @@ class ThreeCardReading extends React.Component {
                 </div>}
 
                 <div className="five-card-reading" >
-                <div className="ui medium images" >
-                {this.state.clicked === true && this.state.readingCards.length !== 0 ? 
+                    <div className="ui medium images" >
+                    {this.state.clicked === true && this.state.readingCards.length !== 0 ? 
                         this.state.readingCards.map(card => 
-
-                        
-                    <Modal trigger={ <div onClick={this.show('blurring')} >
-                            <CardImage key={card.id} card={card} />
+                            <div onClick={this.show('blurring')} >
+                                <CardImage key={card.id} card={card} />
                             </div>
-                            }>
-                            
-                        <div className="my-modal">
-                        <Modal.Header> <h1 >{this.props.clickedCard.name}</h1> </Modal.Header>
-                        <Modal.Content >
-                            <Image size="medium" src={this.getImage(this.props.clickedCard.name)}/>
-                        <Modal.Description>
-                            <p>Meaning Upright: {this.props.clickedCard.meaning_up}</p>
-                            <p>Meaning Reversed: {this.props.clickedCard.meaning_rev}</p>
-                            <p>Description: {this.props.clickedCard.desc}</p>
-
-                        </Modal.Description>
-                        </Modal.Content>
-
-                        </div>
-                    </Modal>
-                            
-                        ) 
-                        
-                        : null }
-                </div>
+                        )
+                    : null}
+                    </div>
                 </div>
             </div>   
         )

--- a/frontend_react/src/components/readings/reading_types/OneCardReading.js
+++ b/frontend_react/src/components/readings/reading_types/OneCardReading.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import { connect } from 'react-redux';
 // import CardInfo from "../../cards/CardInfo";
+import { Modal, Image, Header } from 'semantic-ui-react'
+
 import { createReading } from '../../../store/readings/actions';
 import CardImage from '../../cards/CardImage'
-import { Modal, Image } from 'semantic-ui-react'
+import capitalize from '../../../functions';
+import inlineStyle from '../../../modalStyle';
 
 class OneCardReading extends React.Component {
 
@@ -15,7 +18,6 @@ class OneCardReading extends React.Component {
 
     show = dimmer => () => this.setState({ dimmer, open: true })
     close = () => this.setState({ open: false })
-
 
     getImage = cardName => {
         if (cardName !== undefined) {
@@ -58,36 +60,12 @@ class OneCardReading extends React.Component {
                 <div className="ui large images" >
                 {this.state.clicked === true && this.state.readingCards.length !== 0 ? 
                         this.state.readingCards.map(card => 
-
-                        
-                            <Modal trigger={ 
-                                <div onClick={this.show('blurring')} className="image-card" >
-                                 <CardImage key={card.id} card={card} />
-                                 </div>
-                                 }>
-                                 
-                            <div className="my-modal">
-                            <Modal.Header> <h1 >{this.props.clickedCard.name}</h1> </Modal.Header>
-                            <Modal.Content >
-                                <Image size="medium" src={this.getImage(this.props.clickedCard.name)}/>
-                            <Modal.Description>
-                                <p>Meaning Upright: {this.props.clickedCard.meaning_up}</p>
-                                <p>Meaning Reversed: {this.props.clickedCard.meaning_rev}</p>
-                                <p>Description: {this.props.clickedCard.desc}</p>
-
-                            </Modal.Description>
-                            </Modal.Content>
-
+                            <div onClick={this.show('blurring')} className="image-card" >
+                                <CardImage key={card.id} card={card} />
                             </div>
-                            </Modal>
-                            
-                        ) 
-                        
-                        : null }
+                        )
+                        : null}
                 </div>
-
-                <h4>Take your time to look at the card and see what catches your eye and mind, before reading the description</h4>
-
             </div>   
         )
     }

--- a/frontend_react/src/components/readings/reading_types/ThreeCardReading.js
+++ b/frontend_react/src/components/readings/reading_types/ThreeCardReading.js
@@ -60,30 +60,10 @@ class ThreeCardReading extends React.Component {
                     <div className="ui medium images" >
                         {this.state.clicked === true && this.state.readingCards.length !== 0 ? 
                         this.state.readingCards.map(card => 
-
-                        
-                            <Modal trigger={ 
-                                <div onClick={this.show('blurring')} className="image-card" >
-                                 <CardImage key={card.id} card={card} />
-                                 </div>
-                                 }>
-                                 
-                                    <div className="my-modal">
-                                    <Modal.Header> <h1 >{this.props.clickedCard.name}</h1> </Modal.Header>
-                                    <Modal.Content >
-                                        <Image size="medium" src={this.getImage(this.props.clickedCard.name)}/>
-                                    <Modal.Description>
-                                        <p>Meaning Upright: {this.props.clickedCard.meaning_up}</p>
-                                        <p>Meaning Reversed: {this.props.clickedCard.meaning_rev}</p>
-                                        <p>Description: {this.props.clickedCard.desc}</p>
-
-                                    </Modal.Description>
-                                    </Modal.Content>
-
-                                </div>
-                            </Modal>  
-                        )
-                        : null }      
+                            <div onClick={this.show('blurring')} className="image-card" >
+                                <CardImage key={card.id} card={card} />
+                            </div>)
+                        : null}
                     </div>
                 </div>
             </div>   

--- a/frontend_react/src/functions.js
+++ b/frontend_react/src/functions.js
@@ -1,0 +1,7 @@
+function capitalize(string) {
+    if (string !== undefined) {
+        return string.charAt(0).toUpperCase() + string.slice(1).toLowerCase();
+    }    
+}
+
+export default capitalize;

--- a/frontend_react/src/modalStyle.js
+++ b/frontend_react/src/modalStyle.js
@@ -1,0 +1,9 @@
+const inlineStyle = {
+    modal : {
+      marginTop: '100px !important',
+      marginLeft: 'auto',
+      marginRight: 'auto'
+    }
+  };
+
+  export default inlineStyle;


### PR DESCRIPTION
I styled the Card description modals that appear when you click on a card, so that they appear properly on the page. Part of that was removing repetitive code from the Reading Types and putting that modal call into the Card Image Component.

This makes the Card Info component obsolete now, since that is represented in the Card Image Component. I can also removed the Reading Splash page. It is redundant.